### PR TITLE
release new version 2.15.0

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,6 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'YunoSDK_Example' do
-  pod 'YunoSDK', '~> 2.14.2'
+  pod 'YunoSDK', '~> 2.15.0'
   pod 'Then'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "YunoSDK",
-            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.14.2/YunoSDK_SPM.xcframework.zip",
-            checksum: "fe834cc6485498dc071da55a190c9cfc7d617c451bd70072085c6aa6dd3e3751"
+            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.15.0/YunoSDK_SPM.xcframework.zip",
+            checksum: "eda82943371fe6bdfc087d67aa78fd8e864a270ff87c00e599be2fec39be9632"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 To integrate Yuno SDK with Cocoapods, please add the line below to your Podfile and run pod install.
 
 ```ruby
-pod 'YunoSDK', '~> 2.14.2'
+pod 'YunoSDK', '~> 2.15.0'
 ```
 
 Then run pod install in your directory:

--- a/YunoSDK.podspec
+++ b/YunoSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'YunoSDK'
-  s.version          = '2.14.2'
+  s.version          = '2.15.0'
   s.summary          = 'A short description of YunoSDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates distribution metadata (CocoaPods/SPM URLs, checksums, and docs) to point to the new 2.15.0 binary release; no source logic changes.
> 
> **Overview**
> Updates YunoSDK release references from `2.14.2` to `2.15.0` across CocoaPods and Swift Package Manager.
> 
> This bumps the pod version in `YunoSDK.podspec` and the example `Podfile`, updates the SPM `.binaryTarget` download URL and checksum in `Package.swift`, and refreshes the installation snippet in `README.md` to match the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 586a3afc761934384653204776b7865b14121989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->