### PR TITLE
add render mode and improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ protocol YunoPaymentDelegate: AnyObject {
     var checkoutSession: String { get }
     var countryCode: String { get }
     var language: String? { get }
-    var navigationController: UINavigationController? { get }
+    var viewController: UIViewController? { get }
 
     func yunoCreatePayment(with token: String)
     func yunoPaymentResult(_ result: Yuno.Result)
@@ -163,19 +163,37 @@ class ViewController: YunoPaymentDelegate {
 
     func viewDidLoad() {
         super.viewDidLoad()
-        Yuno.startCheckout(with: self)
     }
 }
 ```
 #### Show Payment Methods
-When you implement a SDK Full you have to add the next view on your layout to show the payment methods available
+When you implement a SDK Full you have to add the next view on your layout to show the payment methods available.
+
+Your delegate must conform to `YunoPaymentFullDelegate` (extends `YunoPaymentDelegate`):
+
 ```swift
-Yuno.methodsView(delegate: self)
-    generator.getPaymentMethodsView(checkoutSession: checkoutSession) { [weak self] (view: UIView) in
-        // Add view to your superview
-    }
+@objc protocol YunoPaymentFullDelegate: YunoPaymentDelegate {
+    func yunoDidSelect(paymentMethod: PaymentMethodSelected)
+    func yunoDidUnenrollSuccessfully(_ success: Bool)
+    func yunoUpdatePaymentMethodsViewHeight(_ height: CGFloat)
 }
 ```
+
+**UIKit** — returns a `UIView`:
+```swift
+Task {
+    let view = await Yuno.getPaymentMethodViewAsync(delegate: self)
+    containerView.addSubview(view)
+}
+```
+
+**SwiftUI** — returns a SwiftUI view:
+```swift
+.task {
+    paymentMethodsView = await Yuno.getPaymentMethodViewAsync(delegate: coordinator)
+}
+```
+
 #### Start Payment
 To start a payment process you have to call the method `startPayment` but if your are using the lite version you must to call `startPaymentLite`
 ```swift

--- a/YunoSwiftUI/YunoSwiftUI.xcodeproj/project.pbxproj
+++ b/YunoSwiftUI/YunoSwiftUI.xcodeproj/project.pbxproj
@@ -18,7 +18,11 @@
 		2BDDAE7F2C406BAC002F2C16 /* OptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDDAE7E2C406BAC002F2C16 /* OptionsView.swift */; };
 		2BDDAE822C4077A4002F2C16 /* PaymentFullView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDDAE812C4077A4002F2C16 /* PaymentFullView.swift */; };
 		2BDDAE852C408083002F2C16 /* SwiftUI+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDDAE842C408083002F2C16 /* SwiftUI+Utils.swift */; };
-		F4695CFD2E69EA700018EA8A /* YunoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F4695CFC2E69EA700018EA8A /* YunoSDK */; };
+		441BDF102FA3CC5100375ABF /* YunoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 441BDF0F2FA3CC5100375ABF /* YunoSDK */; };
+		FA0000010000000000000001 /* PaymentRenderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000010000000000000101 /* PaymentRenderView.swift */; };
+		FA0000010000000000000002 /* PaymentRenderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000010000000000000102 /* PaymentRenderViewModel.swift */; };
+		FA0000010000000000000003 /* EnrollmentRenderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000010000000000000103 /* EnrollmentRenderView.swift */; };
+		FA0000010000000000000004 /* EnrollmentRenderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000010000000000000104 /* EnrollmentRenderViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +38,10 @@
 		2BDDAE7E2C406BAC002F2C16 /* OptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsView.swift; sourceTree = "<group>"; };
 		2BDDAE812C4077A4002F2C16 /* PaymentFullView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentFullView.swift; sourceTree = "<group>"; };
 		2BDDAE842C408083002F2C16 /* SwiftUI+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+Utils.swift"; sourceTree = "<group>"; };
+		FA0000010000000000000101 /* PaymentRenderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRenderView.swift; sourceTree = "<group>"; };
+		FA0000010000000000000102 /* PaymentRenderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRenderViewModel.swift; sourceTree = "<group>"; };
+		FA0000010000000000000103 /* EnrollmentRenderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrollmentRenderView.swift; sourceTree = "<group>"; };
+		FA0000010000000000000104 /* EnrollmentRenderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrollmentRenderViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -41,7 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F4695CFD2E69EA700018EA8A /* YunoSDK in Frameworks */,
+				441BDF102FA3CC5100375ABF /* YunoSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -68,6 +76,8 @@
 			isa = PBXGroup;
 			children = (
 				2BDDAE802C407798002F2C16 /* PaymentFull */,
+				FA0000010000000000000201 /* PaymentRender */,
+				FA0000010000000000000202 /* EnrollmentRender */,
 				2BDDAE7D2C406B9D002F2C16 /* OptionView */,
 				2BDDAE7A2C4067BF002F2C16 /* TransactionView */,
 				2BDDAE6D2C403A08002F2C16 /* ApiKeysView */,
@@ -122,6 +132,24 @@
 			path = PaymentFull;
 			sourceTree = "<group>";
 		};
+		FA0000010000000000000201 /* PaymentRender */ = {
+			isa = PBXGroup;
+			children = (
+				FA0000010000000000000101 /* PaymentRenderView.swift */,
+				FA0000010000000000000102 /* PaymentRenderViewModel.swift */,
+			);
+			path = PaymentRender;
+			sourceTree = "<group>";
+		};
+		FA0000010000000000000202 /* EnrollmentRender */ = {
+			isa = PBXGroup;
+			children = (
+				FA0000010000000000000103 /* EnrollmentRenderView.swift */,
+				FA0000010000000000000104 /* EnrollmentRenderViewModel.swift */,
+			);
+			path = EnrollmentRender;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -139,7 +167,7 @@
 			);
 			name = YunoSwiftUI;
 			packageProductDependencies = (
-				F4695CFC2E69EA700018EA8A /* YunoSDK */,
+				441BDF0F2FA3CC5100375ABF /* YunoSDK */,
 			);
 			productName = YunoSwiftUI;
 			productReference = 2BDDAE5A2C402971002F2C16 /* YunoSwiftUI.app */;
@@ -170,7 +198,7 @@
 			);
 			mainGroup = 2BDDAE512C402971002F2C16;
 			packageReferences = (
-				F4695CFB2E69EA700018EA8A /* XCRemoteSwiftPackageReference "yuno-sdk-ios" */,
+				441BDF0E2FA3CC5100375ABF /* XCRemoteSwiftPackageReference "yuno-sdk-ios" */,
 			);
 			productRefGroup = 2BDDAE5B2C402971002F2C16 /* Products */;
 			projectDirPath = "";
@@ -207,6 +235,10 @@
 				2BDDAE792C4067B5002F2C16 /* TransactionView.swift in Sources */,
 				2BDDAE7C2C406B05002F2C16 /* TransactionViewModel.swift in Sources */,
 				2BDDAE852C408083002F2C16 /* SwiftUI+Utils.swift in Sources */,
+				FA0000010000000000000001 /* PaymentRenderView.swift in Sources */,
+				FA0000010000000000000002 /* PaymentRenderViewModel.swift in Sources */,
+				FA0000010000000000000003 /* EnrollmentRenderView.swift in Sources */,
+				FA0000010000000000000004 /* EnrollmentRenderViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -416,20 +448,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		F4695CFB2E69EA700018EA8A /* XCRemoteSwiftPackageReference "yuno-sdk-ios" */ = {
+		441BDF0E2FA3CC5100375ABF /* XCRemoteSwiftPackageReference "yuno-sdk-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/yuno-payments/yuno-sdk-ios.git";
+			repositoryURL = "https://github.com/yuno-payments/yuno-sdk-ios";
 			requirement = {
-				kind = exactVersion;
-				version = 2.5.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.15.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		F4695CFC2E69EA700018EA8A /* YunoSDK */ = {
+		441BDF0F2FA3CC5100375ABF /* YunoSDK */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F4695CFB2E69EA700018EA8A /* XCRemoteSwiftPackageReference "yuno-sdk-ios" */;
+			package = 441BDF0E2FA3CC5100375ABF /* XCRemoteSwiftPackageReference "yuno-sdk-ios" */;
 			productName = YunoSDK;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/YunoSwiftUI/YunoSwiftUI/EnrollmentRender/EnrollmentRenderView.swift
+++ b/YunoSwiftUI/YunoSwiftUI/EnrollmentRender/EnrollmentRenderView.swift
@@ -1,0 +1,107 @@
+//
+//  EnrollmentRenderView.swift
+//  YunoSwiftUI
+//
+
+import SwiftUI
+import YunoSDK
+
+struct EnrollmentRenderView: View {
+
+    @StateObject var viewModel: EnrollmentRenderView.ViewModel
+    @State private var enrollmentFlow: YunoEnrollmentRenderFlowProtocol?
+    @State private var formView: AnyView?
+
+    init(viewModel: TransactionView.ViewModel) {
+        self._viewModel = StateObject(wrappedValue: EnrollmentRenderView.ViewModel(viewModel))
+    }
+
+    var body: some View {
+        VStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    Text("Your Methods")
+                        .font(.title.bold())
+                        .padding(.top, 16)
+                    cardsShimmers
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 8) {
+                            Text("Enrollment method - \(viewModel.paymentType) (SDK)")
+                                .font(.headline)
+                            if viewModel.renderIsLoading {
+                                ProgressView()
+                                    .scaleEffect(0.8)
+                            }
+                        }
+                        if let formView {
+                            formView
+                                .padding()
+                                .background(Color.white)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                                .shadow(radius: 8.0)
+                                .padding(.top, 24.0)
+                        } else if !viewModel.renderIsLoading {
+                            VStack {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .font(.system(size: 24))
+                                    .foregroundColor(.orange)
+                                Text("Enrollment form not available")
+                                    .font(.headline)
+                                    .foregroundColor(.gray)
+                                Text("Please try again later")
+                                    .font(.subheadline)
+                                    .foregroundColor(.gray)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.gray.opacity(0.1))
+                            .cornerRadius(8)
+                        }
+                    }
+                    cardsShimmers
+                    cardsShimmers
+                }
+                .padding(.horizontal, 20)
+            }
+            .padding(.bottom, 16)
+
+            if enrollmentFlow?.needSubmit ?? false {
+                Button {
+                    enrollmentFlow?.submitForm()
+                } label: {
+                    Text("Merchant - Enroll")
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.black)
+                        .clipShape(Capsule())
+                        .foregroundColor(Color.white)
+                }
+                .padding()
+            }
+        }
+        .onViewDidLoad {
+            let flow = Yuno.startEnrollmentRender(with: viewModel)
+            enrollmentFlow = flow
+            Task {
+                let view = await flow.formView(with: viewModel)
+                await MainActor.run { formView = view }
+            }
+        }
+        .navigationTitle("Enrollment render")
+        .navigationBarTitleDisplayMode(.large)
+    }
+
+    var cardsShimmers: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Cards")
+                .font(.headline)
+                .padding(.bottom, 8)
+            ForEach(0..<3, id: \.self) { _ in
+                Rectangle()
+                    .fill(Color.gray.opacity(0.15))
+                    .frame(height: 24)
+                    .cornerRadius(8)
+            }
+        }
+    }
+}

--- a/YunoSwiftUI/YunoSwiftUI/EnrollmentRender/EnrollmentRenderViewModel.swift
+++ b/YunoSwiftUI/YunoSwiftUI/EnrollmentRender/EnrollmentRenderViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  EnrollmentRenderViewModel.swift
+//  YunoSwiftUI
+//
+
+import Foundation
+import YunoSDK
+import Combine
+
+extension EnrollmentRenderView {
+
+    final class ViewModel: TransactionView.ViewModel {
+
+        let continueSubject = PassthroughSubject<Void, Never>()
+
+        init(_ viewModel: TransactionView.ViewModel) {
+            super.init(apiKey: viewModel.apiKey)
+            customerSession = viewModel.customerSession
+            customer = viewModel.customer
+            paymentType = viewModel.paymentType
+            configLanguage = viewModel.configLanguage
+            configCountryCode = viewModel.configCountryCode
+        }
+    }
+}

--- a/YunoSwiftUI/YunoSwiftUI/PaymentRender/PaymentRenderView.swift
+++ b/YunoSwiftUI/YunoSwiftUI/PaymentRender/PaymentRenderView.swift
@@ -1,0 +1,128 @@
+//
+//  PaymentRenderView.swift
+//  YunoSwiftUI
+//
+
+import SwiftUI
+import YunoSDK
+
+struct PaymentRenderView: View {
+
+    @StateObject var viewModel: PaymentRenderView.ViewModel
+    @State private var paymentFlow: YunoPaymentRenderFlowProtocol?
+    @State private var formView: AnyView?
+
+    init(viewModel: TransactionView.ViewModel) {
+        self._viewModel = StateObject(wrappedValue: PaymentRenderView.ViewModel(viewModel))
+    }
+
+    var body: some View {
+        VStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    Text("Checkout")
+                        .font(.title.bold())
+                        .padding(.top, 16)
+
+                    sectionShimmer(title: "Products", rows: 4, height: 24)
+                    sectionShimmer(title: "Shipping address", rows: 2, height: 24)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 8) {
+                            Text("Payment method - \(viewModel.paymentType) (SDK)")
+                                .font(.headline)
+                            if viewModel.renderIsLoading {
+                                ProgressView()
+                                    .scaleEffect(0.8)
+                            }
+                        }
+                        if let formView {
+                            formView
+                                .padding()
+                                .background(Color.white)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                                .shadow(radius: 8.0)
+                                .padding(.top, 24.0)
+                        } else if !viewModel.renderIsLoading {
+                            unavailableView(
+                                title: "Payment form not available",
+                                subtitle: "Please try again later"
+                            )
+                        }
+                    }
+
+                    sectionShimmer(title: "Order summary", rows: 3, height: 40)
+                }
+                .padding(.horizontal, 20)
+            }
+            .padding(.bottom, 16)
+
+            Button {
+                paymentFlow?.submitForm()
+            } label: {
+                Text("Merchant - Pay")
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color.black)
+                    .clipShape(Capsule())
+                    .foregroundColor(Color.white)
+            }
+            .padding()
+        }
+        .optionsView(
+            type: .ott(token: viewModel.ott) {
+                continuePayment()
+            },
+            showModal: $viewModel.presentOtt
+        )
+        .onReceive(viewModel.continueSubject) {
+            continuePayment()
+        }
+        .onViewDidLoadAsync {
+            let flow = await Yuno.startPaymentRenderFlow(
+                paymentMethodSelected: viewModel.selectedPaymentMethodLite,
+                with: viewModel
+            )
+            await MainActor.run { paymentFlow = flow }
+            let view = await flow.formView(
+                paymentMethodSelected: viewModel.selectedPaymentMethodLite,
+                with: viewModel
+            )
+            await MainActor.run { formView = view }
+        }
+        .navigationTitle("Payment render")
+        .navigationBarTitleDisplayMode(.large)
+    }
+
+    private func continuePayment() {
+        Task { @MainActor in
+            formView = await paymentFlow?.continuePayment()
+        }
+    }
+
+    private func sectionShimmer(title: String, rows: Int, height: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.headline).padding(.bottom, 8)
+            ForEach(0..<rows, id: \.self) { _ in
+                Rectangle()
+                    .fill(Color.gray.opacity(0.15))
+                    .frame(height: height)
+                    .cornerRadius(8)
+            }
+        }
+    }
+
+    private func unavailableView(title: String, subtitle: String) -> some View {
+        VStack {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 24))
+                .foregroundColor(.orange)
+            Text(title).font(.headline).foregroundColor(.gray)
+            Text(subtitle).font(.subheadline).foregroundColor(.gray)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color.gray.opacity(0.1))
+        .cornerRadius(8)
+    }
+}

--- a/YunoSwiftUI/YunoSwiftUI/PaymentRender/PaymentRenderViewModel.swift
+++ b/YunoSwiftUI/YunoSwiftUI/PaymentRender/PaymentRenderViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  PaymentRenderViewModel.swift
+//  YunoSwiftUI
+//
+
+import Foundation
+import YunoSDK
+import Combine
+
+extension PaymentRenderView {
+
+    final class ViewModel: TransactionView.ViewModel {
+
+        let continueSubject = PassthroughSubject<Void, Never>()
+
+        init(_ viewModel: TransactionView.ViewModel) {
+            super.init(apiKey: viewModel.apiKey)
+            checkoutSession = viewModel.checkoutSession
+            customerSession = viewModel.customerSession
+            customer = viewModel.customer
+            paymentType = viewModel.paymentType
+            vaultedToken = viewModel.vaultedToken
+            configLanguage = viewModel.configLanguage
+            configCountryCode = viewModel.configCountryCode
+        }
+
+        override nonisolated func yunoCreatePayment(with token: String, information: [String: Any]) {
+            Task { @MainActor in
+                renderIsLoading = true
+                ott = token
+                presentOtt = true
+                continuePayment = false
+            }
+        }
+    }
+}

--- a/YunoSwiftUI/YunoSwiftUI/SwiftUI+Utils.swift
+++ b/YunoSwiftUI/YunoSwiftUI/SwiftUI+Utils.swift
@@ -24,8 +24,14 @@ struct ViewDidLoadModifier: ViewModifier {
 }
 
 extension View {
-    
+
     func onViewDidLoad(perform action: (() -> Void)? = nil) -> some View {
         self.modifier(ViewDidLoadModifier(action: action))
+    }
+
+    func onViewDidLoadAsync(perform action: @escaping () async -> Void) -> some View {
+        self.modifier(ViewDidLoadModifier(action: {
+            Task { await action() }
+        }))
     }
 }

--- a/YunoSwiftUI/YunoSwiftUI/TransactionView/TransactionView.swift
+++ b/YunoSwiftUI/YunoSwiftUI/TransactionView/TransactionView.swift
@@ -12,7 +12,10 @@ struct TransactionView: View {
     
     @StateObject var viewModel: ViewModel
     @State private var isConfigurationPresented = false
-    
+    @State private var isGeneralExpanded = true
+    @State private var isEnrollmentExpanded = false
+    @State private var isPaymentExpanded = true
+
     init(apiKey: String) {
         _viewModel = StateObject(wrappedValue: ViewModel(apiKey: apiKey))
     }
@@ -38,95 +41,152 @@ struct TransactionView: View {
     var content: some View {
         VStack {
             List {
-                Section(header: Text("General")) {
-                    HStack {
-                        Label("Country", systemImage: "mappin.and.ellipse")
-                            .foregroundColor(.black)
-                        Spacer()
-                        TextField("Code", text: $viewModel.configCountryCode)
-                            .autocapitalization(.none)
-                            .autocorrectionDisabled()
-                            .frame(width: 40.0)
-                            .textFieldStyle(.roundedBorder)
-                            .multilineTextAlignment(.center)
-                    }.frame(maxWidth: .infinity)
-                    HStack {
-                        Label("Language", systemImage: "globe")
-                            .foregroundColor(.black)
-                        Spacer()
-                        TextField("Code", text: $viewModel.configLanguage)
-                            .autocapitalization(.none)
-                            .autocorrectionDisabled()
-                            .frame(width: 40.0)
-                            .textFieldStyle(.roundedBorder)
-                            .multilineTextAlignment(.center)
-                    }.frame(maxWidth: .infinity)
+                Section {
+                    DisclosureGroup(
+                        isExpanded: $isGeneralExpanded,
+                        content: {
+                            HStack {
+                                Label("Country", systemImage: "mappin.and.ellipse")
+                                    .foregroundColor(.black)
+                                Spacer()
+                                TextField("Code", text: $viewModel.configCountryCode)
+                                    .autocapitalization(.none)
+                                    .autocorrectionDisabled()
+                                    .frame(width: 40.0)
+                                    .textFieldStyle(.roundedBorder)
+                                    .multilineTextAlignment(.center)
+                            }.frame(maxWidth: .infinity)
+                            HStack {
+                                Label("Language", systemImage: "globe")
+                                    .foregroundColor(.black)
+                                Spacer()
+                                TextField("Code", text: $viewModel.configLanguage)
+                                    .autocapitalization(.none)
+                                    .autocorrectionDisabled()
+                                    .frame(width: 40.0)
+                                    .textFieldStyle(.roundedBorder)
+                                    .multilineTextAlignment(.center)
+                            }.frame(maxWidth: .infinity)
+                        },
+                        label: {
+                            Text("General")
+                        }
+                    )
                 }
-                
-                Section(header: Text("ENROLLMENT")) {
-                    TextField("Customer Session", text: $viewModel.customerSession)
-                        .frame(height: 54.0)
-                    Button {
-                        Yuno.enrollPayment(
-                            with: viewModel,
-                            showPaymentStatus: true
-                        )
-                    } label: {
-                        HStack {
-                            Label("Execute enrollment", systemImage: "rectangle.and.pencil.and.ellipsis")
-                                .foregroundColor(.black)
-                            Spacer()
-                            Image(systemName: "chevron.right")
+
+                Section {
+                    DisclosureGroup(
+                        isExpanded: $isEnrollmentExpanded,
+                        content: {
+                            TextField("Customer Session", text: $viewModel.customerSession)
+                                .frame(height: 54.0)
+                            Button {
+                                Yuno.enrollPayment(
+                                    with: viewModel,
+                                    showPaymentStatus: true
+                                )
+                            } label: {
+                                HStack {
+                                    Label("Execute enrollment", systemImage: "rectangle.and.pencil.and.ellipsis")
+                                        .foregroundColor(.black)
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                }
+                            }
+                            .disabled(viewModel.customerSession.isEmpty)
+                            .opacity(viewModel.customerSession.isEmpty ? 0.5 : 1.0)
+                            Button {
+                                viewModel.showSdkEnrollmentRenderView = true
+                            } label: {
+                                HStack {
+                                    Label("Execute enrollment RENDER", systemImage: "rectangle.and.pencil.and.ellipsis")
+                                        .foregroundColor(.black)
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                }
+                            }
+                            .disabled(viewModel.customerSession.isEmpty)
+                            .opacity(viewModel.customerSession.isEmpty ? 0.5 : 1.0)
+                        },
+                        label: {
+                            Text("ENROLLMENT")
                         }
-                    }
-                    .disabled(viewModel.customerSession.isEmpty)
-                    .opacity(viewModel.customerSession.isEmpty ? 0.5 : 1.0)
-                    
+                    )
                 }
-                Section(header: Text("PAYMENT")) {
-                    VStack {
-                        TextField("Checkout Session", text: $viewModel.checkoutSession)
-                            .frame(height: 54.0)
-                        
-                    }
-                    TextField("Payment Type", text: $viewModel.paymentType)
-                        .padding([.top, .bottom], 6.0)
-                    TextField("Vaulted Token", text: $viewModel.vaultedToken)
-                        .padding([.top, .bottom], 6.0)
-                    Button {
-                        Yuno.startPaymentLite(with: viewModel,
-                            paymentSelected: viewModel.selectedPaymentMethodLite,
-                            showPaymentStatus: false
-                        )
-                    } label: {
-                        HStack {
-                            Label("Execute payment LITE", systemImage: "dollarsign.square")
-                                .foregroundColor(.black)
-                            Spacer()
-                            Image(systemName: "chevron.right")
+                Section {
+                    DisclosureGroup(
+                        isExpanded: $isPaymentExpanded,
+                        content: {
+                            VStack {
+                                TextField("Checkout Session", text: $viewModel.checkoutSession)
+                                    .frame(height: 54.0)
+
+                            }
+                            TextField("Payment Type", text: $viewModel.paymentType)
+                                .padding([.top, .bottom], 6.0)
+                            TextField("Vaulted Token", text: $viewModel.vaultedToken)
+                                .padding([.top, .bottom], 6.0)
+                            Button {
+                                Yuno.startPaymentLite(with: viewModel,
+                                    paymentSelected: viewModel.selectedPaymentMethodLite,
+                                    showPaymentStatus: false
+                                )
+                            } label: {
+                                HStack {
+                                    Label("Execute payment LITE", systemImage: "dollarsign.square")
+                                        .foregroundColor(.black)
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                }
+                            }
+                            .disabled(viewModel.checkoutSession.isEmpty || viewModel.paymentType.isEmpty)
+                            .opacity(viewModel.checkoutSession.isEmpty || viewModel.paymentType.isEmpty ? 0.5 : 1.0)
+                            Button {
+                                viewModel.loadMethodsView()
+                            } label: {
+                                HStack {
+                                    Label("Execute payment FULL", systemImage: "list.bullet.rectangle")
+                                        .foregroundColor(.black)
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                }
+                            }
+                            .disabled(viewModel.checkoutSession.isEmpty)
+                            .opacity(viewModel.checkoutSession.isEmpty ? 0.5 : 1.0)
+
+                            Button {
+                                viewModel.showSdkPaymentRenderView = true
+                            } label: {
+                                HStack {
+                                    Label("Execute payment RENDER", systemImage: "rectangle.on.rectangle.angled")
+                                        .foregroundColor(.black)
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                }
+                            }
+                            .disabled(viewModel.checkoutSession.isEmpty || viewModel.paymentType.isEmpty)
+                            .opacity(viewModel.checkoutSession.isEmpty || viewModel.paymentType.isEmpty ? 0.5 : 1.0)
+                        },
+                        label: {
+                            Text("PAYMENT")
                         }
-                    }
-                    .disabled(viewModel.checkoutSession.isEmpty || viewModel.paymentType.isEmpty)
-                    .opacity(viewModel.checkoutSession.isEmpty || viewModel.paymentType.isEmpty ? 0.5 : 1.0)
-                    Button {
-                        viewModel.loadMethodsView()
-                    } label: {
-                        HStack {
-                            Label("Execute payment FULL", systemImage: "list.bullet.rectangle")
-                                .foregroundColor(.black)
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                        }
-                    }
-                    .disabled(viewModel.checkoutSession.isEmpty)
-                    .opacity(viewModel.checkoutSession.isEmpty ? 0.5 : 1.0)
-                    
+                    )
                 }
             }
             Group {
                 NavigationLink(
                     destination: LazyView(PaymentFullView().environmentObject(viewModel)),
                     isActive: $viewModel.showSdkFullView,
+                    label: { EmptyView() }
+                )
+                NavigationLink(
+                    destination: LazyView(PaymentRenderView(viewModel: viewModel)),
+                    isActive: $viewModel.showSdkPaymentRenderView,
+                    label: { EmptyView() }
+                )
+                NavigationLink(
+                    destination: LazyView(EnrollmentRenderView(viewModel: viewModel)),
+                    isActive: $viewModel.showSdkEnrollmentRenderView,
                     label: { EmptyView() }
                 )
             }

--- a/YunoSwiftUI/YunoSwiftUI/TransactionView/TransactionViewModel.swift
+++ b/YunoSwiftUI/YunoSwiftUI/TransactionView/TransactionViewModel.swift
@@ -14,14 +14,15 @@ typealias CustomerData = (id: String?, merchantId: String?)
 extension TransactionView {
     
     @MainActor
-    final class ViewModel: ObservableObject {
-        
-        private var anyCancellables: Set<AnyCancellable> = []
+    class ViewModel: ObservableObject {
+
+        var anyCancellables: Set<AnyCancellable> = []
         @Published var presentOtt: Bool = false
         @Published var ott: String = ""
         let apiKey: String
-        private var customer: Customer?
+        var customer: Customer?
         @Published var continuePayment = false
+        @Published var renderIsLoading: Bool = false
         
         @Published var isShowHeadless: Bool = false
         @Published var paymentViewHeight: CGFloat = 0
@@ -53,15 +54,13 @@ extension TransactionView {
         @Published var paymentType: String = ""
         @Published var vaultedToken: String = ""
         @Published var showSdkFullView: Bool = false
+        @Published var showSdkPaymentRenderView: Bool = false
+        @Published var showSdkEnrollmentRenderView: Bool = false
 
         init(apiKey: String) {
             self.apiKey = apiKey
         }
-        
-        var viewController: UIViewController? {
-            UIApplication.shared.windows.first?.rootViewController
-        }
-        
+
         func loadConfiguration() async {
             $continuePayment
                 .removeDuplicates()
@@ -133,7 +132,7 @@ extension TransactionView.ViewModel: YunoPaymentDelegate {
             print(">>>>>>> yunoPaymentResult InternalError")
         case .userCancelled:
             print(">>>>>>> yunoPaymentResult UserCancell")
-        @unknown default:
+        default:
             print(">>>>>>> yunoPaymentResult @unknown")
         }
     }
@@ -143,6 +142,12 @@ extension TransactionView.ViewModel: YunoPaymentDelegate {
             ott = token
             presentOtt = true
             continuePayment = false
+        }
+    }
+
+    nonisolated func onLoading(isLoading: Bool) {
+        Task { @MainActor in
+            renderIsLoading = isLoading
         }
     }
 }
@@ -163,7 +168,7 @@ extension TransactionView.ViewModel: YunoEnrollmentDelegate {
             print(">>>>>>> yunoEnrollmentResult InternalError")
         case .userCancelled:
             print(">>>>>>> yunoEnrollmentResult UserCancel")
-        @unknown default:
+        default:
             print(">>>>>>> yunoEnrollmentResult @unknown")
         }
         


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new render-based payment/enrollment flows and updates the example app navigation/state handling, plus bumps the YunoSDK SPM dependency range; behavior changes are user-facing and depend on new SDK APIs but don’t touch security-critical logic in this repo.
> 
> **Overview**
> Adds **Render mode** examples to the SwiftUI sample app, introducing `PaymentRenderView` and `EnrollmentRenderView` that start render flows (`startPaymentRenderFlow`/`startEnrollmentRender`) and embed the returned form views with explicit submit/continue handling.
> 
> Updates `TransactionView` to organize inputs/actions into expandable sections and to navigate into the new render screens, while `TransactionViewModel` gains render-loading state (`renderIsLoading`), new navigation flags, and an `onLoading` callback.
> 
> Refreshes README checkout docs to use `viewController` (not `navigationController`), documents `YunoPaymentFullDelegate`, and shows async `getPaymentMethodViewAsync` usage for both UIKit and SwiftUI. The SwiftUI sample’s SPM dependency is also updated to `yuno-sdk-ios` `>= 2.15.0` (up to next major) instead of an exact version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd32f832b359705209e414e8c7e05745107a1ddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->