### PR TITLE
Bitrise - Change version number 2.16.0 

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,6 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'YunoSDK_Example' do
-  pod 'YunoSDK', '~> 2.15.0'
+  pod 'YunoSDK', '~> 2.16.0'
   pod 'Then'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "YunoSDK",
-            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.15.0/YunoSDK_SPM.xcframework.zip",
-            checksum: "eda82943371fe6bdfc087d67aa78fd8e864a270ff87c00e599be2fec39be9632"
+            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.16.0/YunoSDK_SPM.xcframework.zip",
+            checksum: "99d7a4e7bff2b6627acea906294b00f1de5dc176b5ed5892f08cf261bd94e1aa"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 To integrate Yuno SDK with Cocoapods, please add the line below to your Podfile and run pod install.
 
 ```ruby
-pod 'YunoSDK', '~> 2.15.0'
+pod 'YunoSDK', '~> 2.16.0'
 ```
 
 Then run pod install in your directory:

--- a/YunoSDK.podspec
+++ b/YunoSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'YunoSDK'
-  s.version          = '2.15.0'
+  s.version          = '2.16.0'
   s.summary          = 'A short description of YunoSDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Change version number 2.16.0 Bitrise workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump affecting dependency references and distribution metadata only. Main risk is consumers pulling the new `2.16.0` binary via CocoaPods/SPM and encountering upstream regressions.
> 
> **Overview**
> Updates all distribution references from **`2.15.0` to `2.16.0`**.
> 
> This bumps the CocoaPods example (`Example/Podfile`), the podspec version (`YunoSDK.podspec`), and the SPM binary target URL/checksum in `Package.swift`, and refreshes the install snippet in `README.md` to point at `2.16.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 940a4e29b40dba289c104270b7f5e93d0783a968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->