### PR TITLE
Bitrise - Change version number 2.17.0 

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,6 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'YunoSDK_Example' do
-  pod 'YunoSDK', '~> 2.16.0'
+  pod 'YunoSDK', '~> 2.17.0'
   pod 'Then'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "YunoSDK",
-            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.16.0/YunoSDK_SPM.xcframework.zip",
-            checksum: "99d7a4e7bff2b6627acea906294b00f1de5dc176b5ed5892f08cf261bd94e1aa"
+            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.17.0/YunoSDK_SPM.xcframework.zip",
+            checksum: "e3e3fa562a76a7e93177778da372d91b1b6b0f1c4d0752f0be279fbe71c28232"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 To integrate Yuno SDK with Cocoapods, please add the line below to your Podfile and run pod install.
 
 ```ruby
-pod 'YunoSDK', '~> 2.16.0'
+pod 'YunoSDK', '~> 2.17.0'
 ```
 
 Then run pod install in your directory:

--- a/YunoSDK.podspec
+++ b/YunoSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'YunoSDK'
-  s.version          = '2.16.0'
+  s.version          = '2.17.0'
   s.summary          = 'A short description of YunoSDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Change version number 2.17.0 Bitrise workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and distribution metadata only; no application or SDK source logic changes in this diff.
> 
> **Overview**
> **Release 2.17.0** — bumps the published SDK version everywhere consumers pin the dependency.
> 
> CocoaPods integration now declares **`2.17.0`** in `YunoSDK.podspec`, the Example app `Podfile`, and the README install snippet. Swift Package Manager’s `Package.swift` binary target points at the **2.17.0** GitHub release artifact and updates the **SPM xcframework checksum** to match the new zip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48fe7dceb574b43ea3141887c8c7cbc208319f91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->