### PR TITLE
Bitrise - Change version number 2.17.2 

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,6 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'YunoSDK_Example' do
-  pod 'YunoSDK', '~> 2.17.1'
+  pod 'YunoSDK', '~> 2.17.2'
   pod 'Then'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "YunoSDK",
-            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.17.1/YunoSDK_SPM.xcframework.zip",
-            checksum: "736e1be63850aab697bc8d6da52b8769b39693fff42818bfb66077e68bedd163"
+            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.17.2/YunoSDK_SPM.xcframework.zip",
+            checksum: "c64013f0a96965d0dc531c2935eaadb34629e588778b571e5165d713aa798db1"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 To integrate Yuno SDK with Cocoapods, please add the line below to your Podfile and run pod install.
 
 ```ruby
-pod 'YunoSDK', '~> 2.17.1'
+pod 'YunoSDK', '~> 2.17.2'
 ```
 
 Then run pod install in your directory:

--- a/YunoSDK.podspec
+++ b/YunoSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'YunoSDK'
-  s.version          = '2.17.1'
+  s.version          = '2.17.2'
   s.summary          = 'A short description of YunoSDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Change version number 2.17.2 Bitrise workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and distribution metadata only; no application or SDK source changes in this diff.
> 
> **Overview**
> Bumps **YunoSDK** from **2.17.1** to **2.17.2** across CocoaPods, Swift Package Manager, and docs.
> 
> **CocoaPods:** `YunoSDK.podspec` version and `Example/Podfile` dependency constraint are updated to `~> 2.17.2`.
> 
> **SPM:** `Package.swift` binary target now points at the **2.17.2** `YunoSDK_SPM.xcframework.zip` release URL with an updated checksum.
> 
> **Docs:** README CocoaPods install snippet matches the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf4c48a00a29e506429be2ec61280be33910b56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->