### PR TITLE
Bitrise - Change version number 2.18.0 

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,6 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'YunoSDK_Example' do
-  pod 'YunoSDK', '~> 2.17.2'
+  pod 'YunoSDK', '~> 2.18.0'
   pod 'Then'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "YunoSDK",
-            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.17.2/YunoSDK_SPM.xcframework.zip",
-            checksum: "c64013f0a96965d0dc531c2935eaadb34629e588778b571e5165d713aa798db1"
+            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.18.0/YunoSDK_SPM.xcframework.zip",
+            checksum: "a6a5f894c185c6c3698efa315725eef0801a14a70c8cc32f0f4cd4b2fedcd063"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 To integrate Yuno SDK with Cocoapods, please add the line below to your Podfile and run pod install.
 
 ```ruby
-pod 'YunoSDK', '~> 2.17.2'
+pod 'YunoSDK', '~> 2.18.0'
 ```
 
 Then run pod install in your directory:

--- a/YunoSDK.podspec
+++ b/YunoSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'YunoSDK'
-  s.version          = '2.17.2'
+  s.version          = '2.18.0'
   s.summary          = 'A short description of YunoSDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Change version number 2.18.0 Bitrise workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime code; risk is limited to consumers pulling the correct 2.18.0 binary artifact.
> 
> **Overview**
> **Bumps the distributed YunoSDK version from 2.17.2 to 2.18.0** across CocoaPods, Swift Package Manager, docs, and the example app.
> 
> The **Example `Podfile`** and **README** now reference `pod 'YunoSDK', '~> 2.18.0'`. **`YunoSDK.podspec`** sets `s.version` to `2.18.0` (binary still resolves from the matching GitHub release URL). **`Package.swift`** points the SPM binary target at the **2.18.0** `YunoSDK_SPM.xcframework.zip` with an updated checksum.
> 
> No application or SDK source changes—only version pins and packaging metadata for the Bitrise release workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit becb89882711a3e072b53f6a3bd809a32acea5bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->