### PR TITLE
update-checksum

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .binaryTarget(
             name: "YunoSDK",
             url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.18.0/YunoSDK_SPM.xcframework.zip",
-            checksum: "a6a5f894c185c6c3698efa315725eef0801a14a70c8cc32f0f4cd4b2fedcd063"
+            checksum: "db2acb75af65b1dfd51a2ebd9386781accec80f98f1ad88ba81bb78f397a1317"
         )
     ]
 )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single checksum field change with no application logic; low risk unless the new hash does not match the published zip, which would break package resolution.
> 
> **Overview**
> Updates the Swift Package Manager **binary target checksum** for `YunoSDK` in `Package.swift`. The download URL still points at release **2.18.0**; only the expected hash for `YunoSDK_SPM.xcframework.zip` changes so SPM can verify the artifact (for example after the zip was replaced or regenerated on the release).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f4a8a851cec5b80150c92eb5bc5c30f789a084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->