### PR TITLE
Bitrise - Change version number 2.19.0 

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,6 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'YunoSDK_Example' do
-  pod 'YunoSDK', '~> 2.18.0'
+  pod 'YunoSDK', '~> 2.19.0'
   pod 'Then'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "YunoSDK",
-            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.18.0/YunoSDK_SPM.xcframework.zip",
-            checksum: "db2acb75af65b1dfd51a2ebd9386781accec80f98f1ad88ba81bb78f397a1317"
+            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.19.0/YunoSDK_SPM.xcframework.zip",
+            checksum: "ec1b87bbe05b3f2d689a0af74977a5d089fb74563d370376860c5b1efc1cc9a7"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 To integrate Yuno SDK with Cocoapods, please add the line below to your Podfile and run pod install.
 
 ```ruby
-pod 'YunoSDK', '~> 2.18.0'
+pod 'YunoSDK', '~> 2.19.0'
 ```
 
 Then run pod install in your directory:

--- a/YunoSDK.podspec
+++ b/YunoSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'YunoSDK'
-  s.version          = '2.18.0'
+  s.version          = '2.19.0'
   s.summary          = 'A short description of YunoSDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Change version number 2.19.0 Bitrise workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release version bump with no application logic changes in the diff.
> 
> **Overview**
> Bumps the published **YunoSDK** version from **2.18.0** to **2.19.0** across CocoaPods, Swift Package Manager, the example app, and docs.
> 
> **CocoaPods:** `YunoSDK.podspec` `s.version` and the Example `Podfile` constraint are updated to `~> 2.19.0`. The README CocoaPods install snippet matches.
> 
> **SPM:** `Package.swift` points the binary target at the **2.19.0** release ZIP and updates the checksum for that artifact.
> 
> No SDK source changes appear in this diff—only version and distribution metadata (likely from a Bitrise release workflow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52d63cd2826fadc85a42d8c38c046fb11ca59772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->