### PR TITLE
chore: remove leftover temp file and vestigial _Pods.xcodeproj symlink

### DIFF
--- a/_Pods.xcodeproj
+++ b/_Pods.xcodeproj
@@ -1,1 +1,0 @@
-Example/Pods/Pods.xcodeproj


### PR DESCRIPTION
## Context
Repo housekeeping: two files in the repo serve no purpose and can confuse contributors.

## Remove Example/.!65717!Podfile
Empty (0-byte) partial-transfer artifact (the .!<id>!<name> pattern used by file-transfer tools) accidentally committed in f8703c5 (v1.10.0). Nothing references it.

## Remove _Pods.xcodeproj
Symlink to Example/Pods/Pods.xcodeproj left over from the pod lib create template. This repo distributes a pre-built XCFramework (no source pod development), no .pbxproj/workspace/podspec references it, and the symlink is broken until pod install runs in Example.

## Notes
- A local modification to Example/YunoSDK.xcodeproj/project.pbxproj was intentionally excluded from this PR.

## Testing
- [x] git status clean for the two removed paths
- [ ] Example app still builds after pod install (no reference to either file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)