### PR TITLE
Bitrise - Change version number 2.21.0 

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,6 @@ use_frameworks!
 platform :ios, '13.0'
 
 target 'YunoSDK_Example' do
-  pod 'YunoSDK', '~> 2.20.0'
+  pod 'YunoSDK', '~> 2.21.0'
   pod 'Then'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "YunoSDK",
-            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.20.0/YunoSDK_SPM.xcframework.zip",
-            checksum: "6ef2f2a88e5b411a9dc9530cff6b38501d244cbe487faee59ec6b4740db96d75"
+            url: "https://github.com/yuno-payments/yuno-sdk-ios/releases/download/2.21.0/YunoSDK_SPM.xcframework.zip",
+            checksum: "85e2df7b2f3830479961eaddfa76e55d2d56a46d0b7e99d7dabb9ba1156962d2"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 To integrate Yuno SDK with Cocoapods, please add the line below to your Podfile and run pod install.
 
 ```ruby
-pod 'YunoSDK', '~> 2.20.0'
+pod 'YunoSDK', '~> 2.21.0'
 ```
 
 Then run pod install in your directory:

--- a/YunoSDK.podspec
+++ b/YunoSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'YunoSDK'
-  s.version          = '2.20.0'
+  s.version          = '2.21.0'
   s.summary          = 'A short description of YunoSDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Change version number 2.21.0 Bitrise workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and distribution metadata only; no application or SDK source logic changes in the diff.
> 
> **Overview**
> Bumps the distributed **YunoSDK** version from **2.20.0** to **2.21.0** across CocoaPods, Swift Package Manager, the example app, and docs.
> 
> **CocoaPods** (`YunoSDK.podspec`, `Example/Podfile`, README): `s.version` and `pod 'YunoSDK', '~> …'` now target **2.21.0**.
> 
> **SPM** (`Package.swift`): the binary target URL points at the **2.21.0** release artifact and the checksum is updated for that zip.
> 
> No SDK implementation files appear in the diff—this is packaging and version metadata only, aligned with a Bitrise release workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0365412c72f94309b0ee9f1b3da235a4ad7b7f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->