### PR TITLE
docs: fix SPM install pin and declare iOS 14 platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 let package = Package(
     name: "YunoSDK",
     defaultLocalization: "en",
+    platforms: [.iOS(.v14)],
     products: [
         .library(
             name: "YunoSDK",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,25 @@ Once you have your Swift package set up, adding YunoSDK as a dependency is as ea
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "1.1.17"))
+    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "2.22.0"))
+]
+```
+
+### Installing the 3.0.0 alpha
+
+The 3.0.0 line is published as a prerelease under the module name `SdkPayments`. It is **not** API-compatible with 2.x and is not recommended for production use.
+
+CocoaPods — pin the exact version:
+
+```ruby
+pod 'SdkPayments', '3.0.0-alpha.1'
+```
+
+Swift Package Manager — pin the exact tag:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", exact: "3.0.0-alpha.1")
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,24 +47,6 @@ dependencies: [
 ]
 ```
 
-### Installing the 3.0.0 alpha
-
-The 3.0.0 line is published as a prerelease under the module name `SdkPayments`. It is **not** API-compatible with 2.x and is not recommended for production use.
-
-CocoaPods — pin the exact version:
-
-```ruby
-pod 'SdkPayments', '3.0.0-alpha.1'
-```
-
-Swift Package Manager — pin the exact tag:
-
-```swift
-dependencies: [
-    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", exact: "3.0.0-alpha.1")
-]
-```
-
 ## Usage
 YunoSDK minimum required version is iOS 14.0
 


### PR DESCRIPTION
Fixes the `master` install instructions. Docs and manifests only — no binary, no version bump.

Split per review: the alpha install instructions moved to #213, against `universal/3.0.0-alpha.2`. This PR is now `master`-scoped only.

## 1. SPM instructions resolved to the 1.x line

`README.md` pinned:

```swift
.package(url: "...", .upToNextMajor(from: "1.1.17"))
```

That means `>=1.1.17, <2.0.0`. There are **111 published `1.x` tags**, the newest being `1.25.0` — so anyone integrating via SPM by following this README got **1.25.0**, two major versions behind what the CocoaPods path gives them.

It resolves cleanly, which is what makes it worth fixing: no error, no warning, so an integrator has no reason to suspect they are on a stale SDK. Now pinned to `2.22.0`, matching `YunoSDK.podspec`.

The CocoaPods line on `master` was already correct and is unchanged (`2.22.0` is confirmed present on the CocoaPods trunk).

## 2. `Package.swift` declared no platform minimum

The shipped binary is built for `arm64-apple-ios14.0` — from the `swift-module-flags` target triple inside `YunoSDK_SPM.xcframework.zip`:

```
// swift-module-flags: -target arm64-apple-ios14.0 -enable-objc-interop ...
```

With no `platforms:` line, SPM can't reject an unsupported deployment target cleanly and the integrator gets an opaque module error instead of "requires iOS 14.0". The README already states iOS 14.0 as the minimum, so this only makes the manifest agree with the documentation.

Verified with `swift package dump-package`:

```json
"platforms": [{"platformName": "ios", "version": "14.0", "options": []}]
```

⏱️ **Timing note:** SPM reads `Package.swift` from the tag it resolves to, not from `master`. Tag `2.22.0` has no `platforms` line, so this takes effect for integrators from the next tagged release onward. The README fix is live on merge.

## Deliberately *not* in this PR

Three further defects were confirmed in **both** `YunoSDK.podspec` (2.22.0) and `SdkPayments.podspec` (alpha), tracked in CORECM-18781:

| | Declared | Actual |
|---|---|---|
| `s.ios.deployment_target` / `s.platform` | `13.0` | binary is `ios14.0` |
| `s.frameworks` | assigned twice — `'UIKit'` then `'Combine'`, so UIKit is dropped | both needed |
| `s.summary` | `'A short description of YunoSDK.'` | placeholder; still says *YunoSDK* in the `SdkPayments` spec |

CocoaPods specs are immutable once pushed to the trunk, so correcting 2.22.0 means **publishing a 2.22.1** — a release decision rather than a docs fix. Worth noting the ticket scopes them as alpha-only, but they are equally live in the shipping 2.22.0 spec.

Refs CORECM-18778, CORECM-18781

🤖 Generated with [Claude Code](https://claude.com/claude-code)
