### PR TITLE
docs: teach the alpha install path on the alpha branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Installation
 
+> **Prerelease.** This branch ships the 3.0.0 alpha, distributed under the module name `SdkPayments`. It is **not** API-compatible with the 2.x line and is not recommended for production use. For the stable SDK, follow the README on `master`.
+
 ### [CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html)
 
-To integrate Yuno SDK with Cocoapods, please add the line below to your Podfile and run pod install.
+To integrate the Yuno SDK alpha with CocoaPods, please add the line below to your Podfile and run pod install.
 
 ```ruby
-pod 'YunoSDK', '~> 2.18.0'
+pod 'SdkPayments', '3.0.0-alpha.1'
 ```
 
 Then run pod install in your directory:
@@ -39,11 +41,11 @@ $ pod install
 ```
 ### [Swift Package Manager](https://swift.org/package-manager/)
 
-Once you have your Swift package set up, adding YunoSDK as a dependency is as easy as adding it to the `dependencies` value of your `Package.swift`.
+Once you have your Swift package set up, adding SdkPayments as a dependency is as easy as adding it to the `dependencies` value of your `Package.swift`.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "1.1.17"))
+    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", exact: "3.0.0-alpha.1")
 ]
 ```
 


### PR DESCRIPTION
Split out of #212 per review — alpha-facing docs belong on the alpha branch. #212 now carries only the two `master`-scoped fixes.

## The problem

This branch ships `3.0.0-alpha.x` under the module name `SdkPayments`, but its README still instructs:

```ruby
pod 'YunoSDK', '~> 2.18.0'
```
```swift
.package(url: "...", .upToNextMajor(from: "1.1.17"))
```

Both install the **legacy** SDK. Following this branch's own README cannot get you the alpha — the defect reported in CORECM-18778 off the July QA baseline.

Worth noting the report quoted `2.18.0` and that is exactly right **here**. `master` has since drifted to `2.22.0`, so the version looks stale only if you check `master` — on this branch the reported string is still present, unchanged.

The inconsistency is already visible within the file: the Usage section uses `import SdkPayments` while the install block above it teaches `YunoSDK`.

## The change

- CocoaPods → `pod 'SdkPayments', '3.0.0-alpha.1'`
- SPM → `exact: "3.0.0-alpha.1"`
- Prerelease banner under **Installation**: names the module rename, states it is not API-compatible with 2.x, and points stable users at `master`
- Prose no longer says "YunoSDK" where it means `SdkPayments`

Both paths were verified to actually resolve:
- `SdkPayments 3.0.0-alpha.1` is published on the CocoaPods trunk
- the `3.0.0-alpha.1` tag carries a matching SPM manifest pointing at `SdkPayments_SPM.xcframework.zip`
- the `exact:` pin syntax validates against `swift-tools-version: 5.6`

## Question for the reviewer

I pinned `3.0.0-alpha.1` because that is the only published alpha today, and this branch's own `SdkPayments.podspec` and `Package.swift` both still say `3.0.0-alpha.1`.

If cutting `3.0.0-alpha.2` bumps those manifests, this README needs to move with them or it goes stale on release day. Happy to change the pin now, or leave it and fold the bump into the release flow — whichever matches how you cut the alpha.

## Not included

The three podspec defects in `SdkPayments.podspec` on this branch — deployment target `13.0` vs a binary built for `ios14.0`, `s.frameworks` assigned twice (dropping UIKit), and the placeholder summary — are CORECM-18781. They are also live in the shipping `YunoSDK.podspec` 2.22.0, so they need a release decision rather than a docs PR.

Refs CORECM-18778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
